### PR TITLE
fix: interaction.isContextMenu is not a function

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,4 +1,7 @@
 addReviewers: true
 reviewers:
-  - whattyu
+  - xHyroM
+  - S222em
+  - Gabe616
+  - Garlic-Team/Maintainers
 numberOfReviewers: 0

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,7 +1,4 @@
 addReviewers: true
 reviewers:
-  - xHyroM
-  - S222em
-  - Gabe616
-  - Garlic-Team/Maintainers
+  - whattyu
 numberOfReviewers: 0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Description
 GCommands is a [discord.js](https://discord.js.org) framework that makes an incredible amount of work easier, it's very customizable.
 
-> **Warning**
+> **Warning**  
 > Currently supports only djs v13.x, v14 support is in progress [here](https://github.com/Garlic-Team/gcommands/pull/539)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 ## Description
 GCommands is a [discord.js](https://discord.js.org) framework that makes an incredible amount of work easier, it's very customizable.
 
+> **Warning**
+> Currently supports only djs v13.x, v14 support is in progress [here](https://github.com/Garlic-Team/gcommands/pull/539)
+
 ## Features
 - Written in TypeScript
 - Supports slash, legacy and context menus

--- a/src/listeners/AutocompleteHandler.ts
+++ b/src/listeners/AutocompleteHandler.ts
@@ -1,4 +1,4 @@
-import type { Interaction } from 'discord.js';
+import type { Interaction, InteractionType } from 'discord.js';
 import { Handlers } from '../lib/managers/HandlerManager';
 import { Listener } from '../lib/structures/Listener';
 import { Logger } from '../lib/util/logger/Logger';
@@ -7,7 +7,7 @@ new Listener({
 	event: 'interactionCreate',
 	name: 'gcommands-autocompleteHandler',
 	run: async (interaction: Interaction): Promise<void> => {
-		if (interaction.isAutocomplete()) {
+		if (interaction.type === InteractionType.ApplicationCommandAutocomplete) {
 			await Promise.resolve(Handlers.autocompleteHandler(interaction)).catch(
 				error => {
 					Logger.error(

--- a/src/listeners/ComponentHandler.ts
+++ b/src/listeners/ComponentHandler.ts
@@ -1,4 +1,4 @@
-import type { Interaction } from 'discord.js';
+import type { Interaction, InteractionType } from 'discord.js';
 import { Handlers } from '../lib/managers/HandlerManager';
 import { Listener } from '../lib/structures/Listener';
 import { Logger } from '../lib/util/logger/Logger';
@@ -7,7 +7,7 @@ new Listener({
 	event: 'interactionCreate',
 	name: 'gcommands-componentHandler',
 	run: async (interaction: Interaction): Promise<void> => {
-		if (interaction.isMessageComponent() || interaction.isModalSubmit()) {
+		if (interaction.type === InteractionType.MessageComponent || interaction.type === InteractionType.ModalSubmit) {
 			await Handlers.componentHandler(interaction).catch(error => {
 				Logger.error(
 					typeof error.code !== 'undefined' ? error.code : '',

--- a/src/listeners/InteractionCommandHandler.ts
+++ b/src/listeners/InteractionCommandHandler.ts
@@ -1,4 +1,4 @@
-import type { Interaction } from 'discord.js';
+import type { Interaction, InteractionType } from 'discord.js';
 import { Handlers } from '../lib/managers/HandlerManager';
 import { Listener } from '../lib/structures/Listener';
 import { Logger } from '../lib/util/logger/Logger';
@@ -7,7 +7,7 @@ new Listener({
 	event: 'interactionCreate',
 	name: 'gcommands-interactionCommandHandler',
 	run: async (interaction: Interaction): Promise<void> => {
-		if (interaction.isCommand() || interaction.isContextMenu()) {
+		if (interaction.type === InteractionType.ApplicationCommand) {
 			await Promise.resolve(
 				Handlers.interactionCommandHandler(interaction),
 			).catch(error => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Solved this error (probably) [17:09:27/ERROR] interaction.isContextMenu is not a function
same as [this pr](https://github.com/Garlic-Team/gcommands/pull/549)

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
